### PR TITLE
Bug 1799042 - Let deb package automatically fetch langpacks at first …

### DIFF
--- a/desktop/deb/distribution/distribution.ini
+++ b/desktop/deb/distribution/distribution.ini
@@ -5,3 +5,4 @@ about=Mozilla Firefox Debian Package
 
 [Preferences]
 browser.shell.checkDefaultBrowser=false
+intl.locale.requested=""


### PR DESCRIPTION
…start up

These prefs are already used in the Snap package, for instance: https://github.com/mozilla-partners/canonical/blob/86c5e5448016a84ac9bc7c904989680216fc777f/desktop/ubuntu/distribution/distribution.ini