### PR TITLE
Bug 1842885: Set dom.ipc.forkserver.enable to true in the .deb distribution Preferences

### DIFF
--- a/desktop/deb/distribution/distribution.ini
+++ b/desktop/deb/distribution/distribution.ini
@@ -6,3 +6,4 @@ about=Mozilla Firefox Debian Package
 [Preferences]
 browser.shell.checkDefaultBrowser=false
 intl.locale.requested=""
+dom.ipc.forkserver.enable=true


### PR DESCRIPTION
Set dom.ipc.forkserver.enable to true in .deb preferences for QA testing. See [Bug 1842885](https://bugzilla.mozilla.org/show_bug.cgi?id=1842885)