### PR TITLE
Bug 1835051 - Remove browser.shell.checkDefaultBrowser=false because default browser check has been fixed

### DIFF
--- a/desktop/deb/distribution/distribution.ini
+++ b/desktop/deb/distribution/distribution.ini
@@ -4,5 +4,4 @@ version=1.0
 about=Mozilla Firefox Debian Package
 
 [Preferences]
-browser.shell.checkDefaultBrowser=false
 intl.locale.requested=""


### PR DESCRIPTION
- [Bug 1897733: “Set Firefox as default browser” checkbox missing from “Welcome to Firefox” page on .deb package](https://bugzilla.mozilla.org/show_bug.cgi?id=1897733#c2)
    - > With fix of [Bug 1710936](https://bugzilla.mozilla.org/show_bug.cgi?id=1710936), about:welcome honors browser.shell.checkDefaultBrowser pref setting. Looks like there is an open [Bug 1835051](https://bugzilla.mozilla.org/show_bug.cgi?id=1835051) around this limitation. Triaging component to Release Engineering to help look into checkDefaultBrowser pref setting for debian packages
- [Bug 1835051: deb: Remove `browser.shell.checkDefaultBrowser=false` after default browser check has been fixed](https://bugzilla.mozilla.org/show_bug.cgi?id=1835051)