### PR TITLE
Bug 1835141 - Add browser.gnome-search-provider.enabled=true to .deb distribution configuration

### DIFF
--- a/desktop/deb/distribution/distribution.ini
+++ b/desktop/deb/distribution/distribution.ini
@@ -7,3 +7,4 @@ about=Mozilla Firefox Debian Package
 browser.shell.checkDefaultBrowser=false
 intl.locale.requested=""
 dom.ipc.forkserver.enable=true
+browser.gnome-search-provider.enabled=true


### PR DESCRIPTION
[Bug 1835141: deb: Register Firefox as Gnome search provider](https://bugzilla.mozilla.org/show_bug.cgi?id=1835141)